### PR TITLE
 Implementation of file_exists new uses MultiStorageFieldFile.name rather than filer.File.path

### DIFF
--- a/cmsplugin_filer_file/models.py
+++ b/cmsplugin_filer_file/models.py
@@ -36,7 +36,7 @@ class FilerFile(CMSPlugin):
         return self.file.icons['32']
 
     def file_exists(self):
-        return self.file.file.storage.exists(self.file.path)
+        return self.file.file.storage.exists(self.file.file.name)
 
     def get_file_name(self):
         if self.file.name in ('', None):


### PR DESCRIPTION
Apparently many storage backends don't implement path. Looking at the docstring in django.core.files.Storage.path, this makes sense:
"Storage systems that can't be accessed using open() should *not* implement this method"
MultiStorageFieldFile.name works correctly with multiple storage backends

Also see conversation on:
https://groups.google.com/forum/?utm_source=digest&utm_medium=email#!topic/django-filer/ui3vERUQ-QA
