### PR TITLE
Fixed broken template name in folder plugin

### DIFF
--- a/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
+++ b/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
@@ -19,10 +19,10 @@ jQuery(document).ready(function ($) {
 {% if object.view_option == "list" %}
     <div class="cmsplugin_filer_folder_list" id="folder_{{ instance.id }}">
         <!--The files should go there    -->
-        {% if folder_children %}
+        {% if folder_folders %}
         <p>{% trans "Folders" %}</p>
         <ul>
-            {% for folder in folder_children %}
+            {% for folder in folder_folders %}
                 <li>{{ folder }}</li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
The template variable is name incorrectly for the folder plugin.  This should fix it.

See: https://github.com/stefanfoulis/cmsplugin-filer/blob/develop/cmsplugin_filer_folder/cms_plugins.py#L60

