### PR TITLE
Fixes issue 171

### DIFF
--- a/cmsplugin_filer_file/migrations/0004_fix_table_names.py
+++ b/cmsplugin_filer_file/migrations/0004_fix_table_names.py
@@ -12,6 +12,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filerfile', 'cmsplugin_filer_file_filerfile'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_folder/migrations/0003_move_view_option_to_style.py
+++ b/cmsplugin_filer_folder/migrations/0003_move_view_option_to_style.py
@@ -11,6 +11,10 @@ class Migration(DataMigration):
         # (old_name, new_name),
         ('cmsplugin_filerfolder', 'cmsplugin_filer_folder_filerfolder'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_new_to_old(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_folder/migrations/0005_fix_table_names.py
+++ b/cmsplugin_filer_folder/migrations/0005_fix_table_names.py
@@ -11,6 +11,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filerfolder', 'cmsplugin_filer_folder_filerfolder'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_image/migrations/0012_fix_table_names.py
+++ b/cmsplugin_filer_image/migrations/0012_fix_table_names.py
@@ -11,6 +11,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filerimage', 'cmsplugin_filer_image_filerimage'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_link/migrations/0003_fix_table_names.py
+++ b/cmsplugin_filer_link/migrations/0003_fix_table_names.py
@@ -12,6 +12,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filerlinkplugin', 'cmsplugin_filer_link_filerlinkplugin'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_teaser/migrations/0008_fix_table_names.py
+++ b/cmsplugin_filer_teaser/migrations/0008_fix_table_names.py
@@ -12,6 +12,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filerteaser', 'cmsplugin_filer_teaser_filerteaser'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)

--- a/cmsplugin_filer_video/migrations/0002_fix_table_names.py
+++ b/cmsplugin_filer_video/migrations/0002_fix_table_names.py
@@ -12,6 +12,10 @@ class Migration(SchemaMigration):
         # (old_name, new_name),
         ('cmsplugin_filervideo', 'cmsplugin_filer_video_filervideo'),
     )
+    
+    needed_by = (
+        ("cms", "0069_static_placeholder_permissions"),
+    )
 
     def forwards(self, orm):
         rename_tables_old_to_new(db, self.cms_plugin_table_mapping)


### PR DESCRIPTION
Added a `needed_by` pegged to the last migration in djangocms 3.0.x before treebeard replaced mptt in the 3.1.x develops branch.  This makes cmsplugin-filer compat with djangocms 3.1.x.