### PR TITLE
Update __init__.py

### DIFF
--- a/cmsplugin_filer_utils/__init__.py
+++ b/cmsplugin_filer_utils/__init__.py
@@ -8,7 +8,7 @@ class FilerPluginManager(models.Manager):
         super(FilerPluginManager, self).__init__()
 
     def get_query_set(self):
-        qs = super(FilerPluginManager, self).get_query_set()
+        qs = super(FilerPluginManager, self).get_queryset()
         if self._select_related:
             qs = qs.prefetch_related(*self._select_related)
         return qs


### PR DESCRIPTION
cmsplugin_filer_utils/__init__.py:5: RemovedInDjango18Warning: `FilerPluginManager.get_query_set` method should be renamed `get_queryset`.