### PR TITLE
XSS fix for 'firstof' in folder template

### DIFF
--- a/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
+++ b/cmsplugin_filer_folder/templates/cmsplugin_filer_folder/plugins/folder/default.html
@@ -14,7 +14,12 @@ jQuery(document).ready(function ($) {
 {% endaddtoblock %}
 
 
-{% firstof object.title object.folder.name  %}
+{# Does not use `firstof` as pre Django1.8, `firstof` does not escape its output. #}
+{% if object.title %}
+    {{ object.title }}
+{% else %}
+    {{ object.folder.name  }}
+{% endif %}
 
 {% if object.view_option == "list" %}
     <div class="cmsplugin_filer_folder_list" id="folder_{{ instance.id }}">


### PR DESCRIPTION
The `firstof` tag does not escape its output in Django<=1.7 (https://docs.djangoproject.com/en/1.7/ref/templates/builtins/#firstof).

While there is `{% load firstof from future %}`, this only appears in Django 1.6 (and `setup.py` says "Django >= 1.4") so I went for the straightforward approach.