### PR TITLE
Fix datamigration with django CMS 3.1

### DIFF
--- a/cmsplugin_filer_folder/migrations/0003_move_view_option_to_style.py
+++ b/cmsplugin_filer_folder/migrations/0003_move_view_option_to_style.py
@@ -18,14 +18,13 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         rename_tables_new_to_old(db, self.cms_plugin_table_mapping)
-        # rename_tables_new_to_old(db, self.cms_plugin_table_mapping)
-        for obj in orm['cmsplugin_filer_folder.filerfolder'].objects.all():
+        for obj in orm.Filerfolder.objects.all():
             obj.style = obj.view_option
             obj.save()
 
     def backwards(self, orm):
         rename_tables_new_to_old(db, self.cms_plugin_table_mapping)
-        for obj in orm['cmsplugin_filer_folder.filerfolder'].objects.all():
+        for obj in orm.Filerfolder.objects.all():
             obj.view_option = obj.style
             obj.save()
 


### PR DESCRIPTION
We need to use real model, not historic one during the data migration…to get the treebeard fields